### PR TITLE
Implement logout hook and profile integration

### DIFF
--- a/api/authApi.ts
+++ b/api/authApi.ts
@@ -1,7 +1,12 @@
-import { LOGIN_URL } from "@/constants/url/url";
+import { LOGIN_URL, LOGOUT_URL } from "@/constants/url/url";
 import { baseFetcher } from "./baseFetcher";
-import { ILoginRequest, ILoginResponse } from "@/types/auth";
-import { IRegisterRequest, IRegisterResponse } from "@/types/auth";
+import {
+  ILoginRequest,
+  ILoginResponse,
+  IRegisterRequest,
+  IRegisterResponse,
+  ILogoutResponse,
+} from "@/types/auth";
 
 export const loginAPI = (data: ILoginRequest) =>
   baseFetcher<ILoginResponse>(LOGIN_URL, {
@@ -13,4 +18,9 @@ export const registerAPI = (data: IRegisterRequest) =>
   baseFetcher<IRegisterResponse>("/user/register", {
     method: "POST",
     data,
+  });
+
+export const logoutAPI = () =>
+  baseFetcher<ILogoutResponse>(LOGOUT_URL, {
+    method: "POST",
   });

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,3 +1,20 @@
+import React from 'react';
+import { useRouter } from 'expo-router';
 
-import Profile from '../../screens/ProfileScreen'
-export default Profile
+import ProfileScreen from '../../screens/ProfileScreen';
+import { useLogout } from '@/hooks/useLogout';
+
+export default function ProfileTab() {
+  const router = useRouter();
+  const { mutate: logoutMutation, isPending } = useLogout();
+
+  const handleLogout = () => {
+    logoutMutation(undefined, {
+      onSuccess: () => {
+        router.replace('/(auth)');
+      },
+    });
+  };
+
+  return <ProfileScreen onLogout={handleLogout} logoutLoading={isPending} />;
+}

--- a/components/Profile/ProfileOverview.tsx
+++ b/components/Profile/ProfileOverview.tsx
@@ -6,6 +6,7 @@ import {
   ScrollView,
   Image,
   TouchableOpacity,
+  ActivityIndicator,
 } from 'react-native';
 import {
   User,
@@ -22,20 +23,17 @@ import {
 
 interface ProfileOverviewProps {
   colors: any;
+  onLogout?: () => void;
+  logoutLoading?: boolean;
 }
 
-export default function ProfileOverview({ colors }: ProfileOverviewProps) {
+export default function ProfileOverview({ colors, onLogout, logoutLoading = false }: ProfileOverviewProps) {
   const userStats = [
     { icon: Trophy, label: 'Events Participated', value: '12', color: colors.warning },
     { icon: Award, label: 'Achievements', value: '8', color: colors.success },
     { icon: Target, label: 'Goals Completed', value: '24', color: colors.primary },
     { icon: Activity, label: 'Active Days', value: '156', color: colors.accent },
   ];
-
-  const handleLogout = () => {
-    // Implement logout logic
-    console.log('Logout pressed');
-  };
 
   const handleSettings = () => {
     // Navigate to settings
@@ -176,12 +174,19 @@ export default function ProfileOverview({ colors }: ProfileOverviewProps) {
             <Text style={[styles.actionButtonText, { color: colors.onSurface }]}>Settings</Text>
           </TouchableOpacity>
           
-          <TouchableOpacity 
+          <TouchableOpacity
             style={[styles.actionButton, styles.logoutButton, { backgroundColor: colors.error + '20' }]}
-            onPress={handleLogout}
+            onPress={onLogout}
+            disabled={logoutLoading}
           >
-            <LogOut size={20} color={colors.error} />
-            <Text style={[styles.actionButtonText, { color: colors.error }]}>Logout</Text>
+            {logoutLoading ? (
+              <ActivityIndicator size="small" color={colors.error} />
+            ) : (
+              <>
+                <LogOut size={20} color={colors.error} />
+                <Text style={[styles.actionButtonText, { color: colors.error }]}>Logout</Text>
+              </>
+            )}
           </TouchableOpacity>
         </View>
       </View>

--- a/constants/url/url.ts
+++ b/constants/url/url.ts
@@ -1,5 +1,6 @@
 export const LOGIN_URL = "/user/login";
 export const REGISTER_URL = "/user/register";
+export const LOGOUT_URL = "/user/logout";
 export const CREATE_EVENT_URL = "/event/create";
 export const GET_MY_EVENT_URL = "/event/my-events";
 export const GET_EVENT_URL = "/event/";

--- a/hooks/useLogout.ts
+++ b/hooks/useLogout.ts
@@ -1,0 +1,29 @@
+import { useMutation } from "@tanstack/react-query";
+import { Alert } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import { logoutAPI } from "@/api/authApi";
+import { ILogoutResponse } from "@/types/auth";
+import { useAuth } from "@/context/auth-context";
+
+export const useLogout = () => {
+  const { logout } = useAuth();
+
+  return useMutation({
+    mutationFn: logoutAPI,
+    onSuccess: async (_data: ILogoutResponse) => {
+      await AsyncStorage.removeItem("accessToken");
+      await AsyncStorage.removeItem("refreshToken");
+      await AsyncStorage.removeItem("user");
+      logout();
+    },
+    onError: (err: any) => {
+      console.error("❌ Logout failed", err);
+      Alert.alert(
+        "Logout Failed",
+        err?.response?.data?.message || "Unable to logout. Please try again."
+      );
+    },
+  });
+};
+

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -20,7 +20,12 @@ const { width } = Dimensions.get('window');
 
 const tabs = ['Overview', 'Edit Profile', 'Security', 'Preferences'];
 
-export default function ProfileScreen() {
+interface ProfileScreenProps {
+  onLogout?: () => void;
+  logoutLoading?: boolean;
+}
+
+export default function ProfileScreen({ onLogout, logoutLoading = false }: ProfileScreenProps) {
   const [tabIndex, setTabIndex] = useState<number>(0);
   const scrollX = useState<Animated.Value>(new Animated.Value(0))[0];
   
@@ -39,7 +44,13 @@ export default function ProfileScreen() {
   const renderTabContent = () => {
     switch (tabIndex) {
       case 0:
-        return <ProfileOverview colors={colors} />;
+        return (
+          <ProfileOverview
+            colors={colors}
+            onLogout={onLogout}
+            logoutLoading={logoutLoading}
+          />
+        );
       case 1:
         return <EditProfile colors={colors} />;
       case 2:
@@ -47,7 +58,13 @@ export default function ProfileScreen() {
       case 3:
         return <Preferences colors={colors} />;
       default:
-        return <ProfileOverview colors={colors} />;
+        return (
+          <ProfileOverview
+            colors={colors}
+            onLogout={onLogout}
+            logoutLoading={logoutLoading}
+          />
+        );
     }
   };
 

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -43,3 +43,7 @@ export interface IRegisterResponse {
     weight?: number;
   };
 }
+
+export interface ILogoutResponse {
+  message: string;
+}


### PR DESCRIPTION
## Summary
- add logout endpoint constant
- add logout types and API function
- create `useLogout` hook
- extend profile screens to handle logout with loading state
- implement logout functionality in profile tab

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e1ccd40483279fce50f53348ee9c